### PR TITLE
Implement UnsafeAtomics.fence

### DIFF
--- a/src/UnsafeAtomics.jl
+++ b/src/UnsafeAtomics.jl
@@ -6,6 +6,7 @@ function load end
 function store! end
 function cas! end
 function modify! end
+function fence end
 
 function add! end
 function sub! end
@@ -17,6 +18,7 @@ function xor! end
 function max! end
 function min! end
 
+# =>
 right(_, x) = x
 
 module Internal

--- a/test/UnsafeAtomicsTests/src/test_core.jl
+++ b/test/UnsafeAtomicsTests/src/test_core.jl
@@ -1,6 +1,6 @@
 module TestCore
 
-using UnsafeAtomics: UnsafeAtomics, acquire, release, acq_rel, right
+using UnsafeAtomics: UnsafeAtomics, monotonic, acquire, release, acq_rel, seq_cst, right
 using UnsafeAtomics.Internal: OP_RMW_TABLE, inttypes, floattypes
 using Test
 
@@ -16,6 +16,7 @@ function test_default_ordering()
     @testset for T in (asbits(T) for T in inttypes if T <: Unsigned)
         test_default_ordering(T)
     end
+    UnsafeAtomics.fence()
 end
 
 rmw_table_for(@nospecialize T) =
@@ -58,6 +59,11 @@ function test_explicit_ordering()
     @testset for T in [UInt, Float64]
         test_explicit_ordering(T)
     end
+    UnsafeAtomics.fence(monotonic)
+    UnsafeAtomics.fence(acquire)
+    UnsafeAtomics.fence(release)
+    UnsafeAtomics.fence(acq_rel)
+    UnsafeAtomics.fence(seq_cst)
 end
 
 function test_explicit_ordering(T::Type)


### PR DESCRIPTION
Mostly using LLVM fence intrinsic (since we require julia 1.10 that's thankfully directly accesible),
but on x86 we have observed that on Zen systems LLVM choice of fence is slow.

x-ref: https://github.com/llvm/llvm-project/pull/106555

The PR above is backported to our version of LLVM 19 https://github.com/JuliaLang/llvm-project/commit/49c6812e2c4624a7f0cee34859a0511209f44b67
but not yet in mainline Julia.


Closes #16 